### PR TITLE
supported DLLS directory for portability

### DIFF
--- a/port/PyAssimp/pyassimp/helper.py
+++ b/port/PyAssimp/pyassimp/helper.py
@@ -15,7 +15,10 @@ import logging;logger = logging.getLogger("pyassimp")
 
 from .errors import AssimpError
 
-additional_dirs, ext_whitelist = [],[]
+import sys
+additional_dirs, ext_whitelist = [
+    os.path.dirname( sys.modules['pyassimp'].__file__ ).replace('\\','/')+'/DLLS/'
+    ],[]
 
 # populate search directories and lists of allowed file extensions
 # depending on the platform we're running on.


### PR DESCRIPTION
added support for a portable DLLS/ directory in extension directory for assimp.dll or assimp.so.
